### PR TITLE
Add branch protection documentation

### DIFF
--- a/.github/branch-protection.md
+++ b/.github/branch-protection.md
@@ -1,0 +1,14 @@
+# Branch Protection Settings
+#
+# This file defines branch protection rules using GitHub repository settings.
+# Learn more about branch protection at: 
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches
+
+# Branch protection for the main branch:
+# - Requires pull requests
+# - Requires at least 1 review before merging
+# - Dismisses stale reviews
+# - Enforces for administrators
+
+# Additionally, the repository uses a GitHub Action to ensure these rules
+# are applied correctly. See the workflow file at .github/workflows/branch-protection.yml


### PR DESCRIPTION
This PR adds a documentation file explaining branch protection settings for this repository.

The `.github/branch-protection.md` file serves as documentation for the branch protection rules that should be applied to the main branch. It helps contributors understand why these protections are in place and how they work.

Since we've already merged the GitHub Actions workflow to automatically set up branch protection, this PR simply adds documentation to make the protection more visible and understood by contributors.